### PR TITLE
Zugriff auf Spiele anderer Landesverbände + minor bug fixes

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -20,6 +20,7 @@ JWT_SECRET=your-jwt-secret  # Setze ein beliebiges Secret
 ## Mailversand Einstellungen
 UNIX_SENDMAIL=true||false  # FALSE = Benutze SMTP Server; TRUE = Benutze SENDMAIL
 MAILER_USER=my_mail@example.com  # Versand E-Mail Adresse
+MAILER_REPLY_TO=replyto@example.com  # E-Mail die als ReplyTo verwendet wird
 
 MAILER_HOST=example.com  # SMTP Server
 MAILER_PORT=your_port||25|465|587  # SMTP Port

--- a/.env.sample
+++ b/.env.sample
@@ -19,13 +19,13 @@ JWT_SECRET=your-jwt-secret  # Setze ein beliebiges Secret
 
 ## Mailversand Einstellungen
 UNIX_SENDMAIL=true||false  # FALSE = Benutze SMTP Server; TRUE = Benutze SENDMAIL
-MAILER_USER=my_mail@example.com
+MAILER_USER=my_mail@example.com  # Versand E-Mail Adresse
 
-MAILER_HOST=mail@example.com
-MAILER_PORT=your_port||25|465|587
-MAILER_SECURE=false||true
-MAILER_USER=your_username
-MAILER_PASS=your_pass
+MAILER_HOST=example.com  # SMTP Server
+MAILER_PORT=your_port||25|465|587  # SMTP Port
+MAILER_SECURE=false||true  # Verbindung verschlüsselt?
+MAILER_USER=your_username  # SMTP Username
+MAILER_PASS=your_pass  #  SMTP User Password
 
 ## Frontend Einstellungen
 FRONTEND_URL=https://srbasar.de

--- a/.env.sample
+++ b/.env.sample
@@ -18,7 +18,7 @@ PORT=3000
 JWT_SECRET=your-jwt-secret  # Setze ein beliebiges Secret
 
 ## Mailversand Einstellungen
-UNIX_SENTMAIL=true||false  # 
+UNIX_SENDMAIL=true||false  # 
 MAILER_USER=my_mail@example.com
 
 MAILER_HOST=mail@example.com

--- a/.env.sample
+++ b/.env.sample
@@ -18,7 +18,7 @@ PORT=3000
 JWT_SECRET=your-jwt-secret  # Setze ein beliebiges Secret
 
 ## Mailversand Einstellungen
-UNIX_SENDMAIL=true||false  # 
+UNIX_SENDMAIL=true||false  # FALSE = Benutze SMTP Server; TRUE = Benutze SENDMAIL
 MAILER_USER=my_mail@example.com
 
 MAILER_HOST=mail@example.com

--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 TEAM_SL_USERNAME=your_username
 TEAM_SL_PASSWORD=your_password
-
+TEAM_SL_VERBAND_ID=your_verbandsid
 
 DATABASE_SERVER=127.0.0.1
 DATABASE_PORT=3306

--- a/.env.sample
+++ b/.env.sample
@@ -28,5 +28,5 @@ MAILER_USER=your_username  # SMTP Username
 MAILER_PASS=your_pass  #  SMTP User Password
 
 ## Frontend Einstellungen
-FRONTEND_URL=https://srbasar.de
+FRONTEND_URL=https://srbasar.de  # URL deiner Seite; WICHTIG: Kein 'trailing slash'!
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173

--- a/.env.sample
+++ b/.env.sample
@@ -1,19 +1,24 @@
-TEAM_SL_USERNAME=your_username
-TEAM_SL_PASSWORD=your_password
-TEAM_SL_VERBAND_ID=your_verbandsid
+## TeamSL Einstellungen
+TEAM_SL_USERNAME=your_username  # Benutzername eines SR-Ansetzer Accounts
+TEAM_SL_PASSWORD=your_password  # Passwort eines SR-Ansetzer Accounts
+TEAM_SL_VERBAND_ID=your_verbandsid  # Setze Verbands-ID für Filter, zB 3 für Berlin oder 7 für NDS
 
-DATABASE_SERVER=127.0.0.1
-DATABASE_PORT=3306
+## MySQL Datenbank Einstellungen
+DATABASE_SERVER=127.0.0.1  
+DATABASE_PORT=3306 
 DATABASE_USER=user
 DATABASE_PASSWORD=pass
 DATABASE=db
 
+## Backend Einstellungen
 NODE_ENV=development
 PORT=3000
 
-JWT_SECRET=your-jwt-secret
+## Kommunikation Frontend <-> Backend
+JWT_SECRET=your-jwt-secret  # Setze ein beliebiges Secret
 
-UNIX_SENTMAIL=true||false
+## Mailversand Einstellungen
+UNIX_SENTMAIL=true||false  # 
 MAILER_USER=my_mail@example.com
 
 MAILER_HOST=mail@example.com
@@ -22,6 +27,6 @@ MAILER_SECURE=false||true
 MAILER_USER=your_username
 MAILER_PASS=your_pass
 
+## Frontend Einstellungen
 FRONTEND_URL=https://srbasar.de
-
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173

--- a/src/services/mailerService.js
+++ b/src/services/mailerService.js
@@ -10,7 +10,13 @@ class MailerService {
 
   createTransporter() {
     // Konfiguriere den Transporter basierend auf Umgebungsvariablen
-    if (!process.env.UNIX_SENDMAIL) {
+    // Interpretiere UNIX_SENDMAIL als echtes Boolean
+    const useUnixSendmail =
+      typeof process.env.UNIX_SENDMAIL === 'string'
+        ? ['true', '1', 'yes'].includes(process.env.UNIX_SENDMAIL.toLowerCase())
+        : false;
+
+    if (!useUnixSendmail) {
       // SMTP-Konfiguration
       return nodemailer.createTransport({
         host: process.env.MAILER_HOST,

--- a/src/services/teamSLService.js
+++ b/src/services/teamSLService.js
@@ -4,6 +4,9 @@ const { Op } = require("sequelize");
 const { fieldFn } = require("../utils/licenseUtils");
 const path = require('path');
 
+// Konfigurierbare Verbands-ID (Fallback auf Standardwert 3)
+const VERBAND_ID = parseInt(process.env.TEAM_SL_VERBAND_ID || "3", 10);
+
 class TeamSLService {
   constructor() {
     this.baseURL = "https://www.basketball-bund.net";
@@ -268,7 +271,7 @@ class TeamSLService {
         sortBy: 0,
         spielklasseIds: [],
         token: "",
-        verbandIds: [3],
+        verbandIds: [VERBAND_ID],
         startAtIndex: index,
       });
 


### PR DESCRIPTION
## Zweck des PR

Dieser PR ermöglicht in erster Linie Spiele von anderen Landesverbänden zu laden. Zusätzlich wurden die Mail-Konfiguration etwas flexibler und robuster gestaltet, sowie die Variablen in der .env besser erklärt.

## Änderungen

- **TeamSL-Service**
  - Neue Environment-Variable `TEAM_SL_VERBAND_ID` eingeführt.
  - `teamSLService` nutzt jetzt `TEAM_SL_VERBAND_ID` statt der fest verdrahteten `verbandIds: [3]`.
  - Fallback auf `3`, falls `TEAM_SL_VERBAND_ID` nicht gesetzt ist (verändert also das bisherige Standardverhalten nicht).

- **Mailer-Service**
  - `UNIX_SENDMAIL` wird jetzt als echtes Boolean interpretiert:
    - `UNIX_SENDMAIL=true`, `1` oder `yes` (case-insensitive) → Mailversand über `/usr/sbin/sendmail`.
    - `UNIX_SENDMAIL` nicht gesetzt oder andere Werte (`false`, `0`, leer, etc.) → Mailversand über SMTP (`MAILER_HOST`, `MAILER_PORT`, `MAILER_SECURE`, `MAILER_USER`, `MAILER_PASS`).
  - Verhindert, dass z. B. `UNIX_SENDMAIL=false` trotzdem sendmail aktiviert und zu `ENOENT: spawn /usr/sbin/sendmail` führt.

## Konfigurationsänderungen

Bitte `.env` anpassen:

### TeamSL
TEAM_SL_VERBAND_ID=3   # optional, Standard bleibt 3

### Mail

**Entweder SMTP (empfohlen, insbesondere lokal):**

UNIX_SENDMAIL=false
MAILER_HOST=smtp.example.com
MAILER_PORT=587
MAILER_SECURE=false
MAILER_USER=...
MAILER_PASS=...

**Oder UNIX sendmail:**

UNIX_SENDMAIL=true
(Voraussetzung: /usr/sbin/sendmail ist im System vorhanden)

## Tests

- Passwort-zurücksetzen-Flow getestet:
  - Mit `UNIX_SENDMAIL=false` → E-Mail-Versand über SMTP erfolgreich.
  - Mit `UNIX_SENDMAIL=true` auf einem System **ohne** `/usr/sbin/sendmail` tritt erwartungsgemäß `ENOENT: spawn /usr/sbin/sendmail` auf (Hinweis im Log).
- TeamSL-Cronjob getestet:
  - Läuft weiterhin mit Default `TEAM_SL_VERBAND_ID=3`.
  - Mit anderem `TEAM_SL_VERBAND_ID` werden die Ligen über die neue Verband-ID geladen.